### PR TITLE
Change target definition for connect command

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,14 @@ go run github.com/qbee-io/qbee-cli@latest
 export QBEE_EMAIL=<email>
 export QBEE_PASSWORD=<password>
 
-qbee-cli connect -t <protocol>:<localPort>:<deviceID>:<remotePort>
+qbee-cli connect -d <deviceID> -t <target>[,<target> ...]
 ```
 
 Where:
-- `protocol` is either `tcp` or `udp`
-- `localPort` is the local port on which tunnel will listen for connections/packets
 - `deviceID` identifies to which device we want to connect (public key digest)
+- `target` defines a singe port forwarding target as `<localPort>:<remoteHost>:<remotePort>`
+- `localPort` is the local port on which tunnel will listen for connections/packets
+- `remoteHost` must be set to _localhost_
 - `remotePort` is the remote port on which tunnel will connect to on the device
 
 # Use as a Go module

--- a/client/remote_access.go
+++ b/client/remote_access.go
@@ -33,8 +33,8 @@ type RemoteAccessTarget struct {
 	// Can be either "tcp" or "udp".
 	Protocol string
 
-	// Device identifies the target device by its public key digest (SHA256).
-	Device string
+	// RemoteHost is the host of the remote machine to which the loca port is forwarded.
+	RemoteHost string
 
 	// LocalPort is the port on the local machine to which the remote port is forwarded.
 	// If set to 0, a random port will be chosen.
@@ -44,8 +44,8 @@ type RemoteAccessTarget struct {
 	RemotePort uint16
 }
 
-// isValidDeviceID checks if the provided device ID is valid.
-func isValidDeviceID(deviceID string) bool {
+// IsValidDeviceID checks if the provided device ID is valid.
+func IsValidDeviceID(deviceID string) bool {
 	// make sure length is correct before we check the content
 	if len(deviceID) != 64 {
 		return false
@@ -63,39 +63,55 @@ func isValidDeviceID(deviceID string) bool {
 
 // ParseRemoteAccessTarget parses a remote access target string.
 // The target string has the following format:
-// <proto>:<local_port>:<device>:<remote_port>
+// <local_port>:<remote_host>:<remote_port>[/udp]
 func ParseRemoteAccessTarget(targetString string) (RemoteAccessTarget, error) {
 	target := RemoteAccessTarget{}
 
 	// Split the target string into its parts.
 	parts := strings.Split(targetString, ":")
 
-	if len(parts) != 4 {
+	if len(parts) != 3 {
 		return target, fmt.Errorf("invalid format")
-	}
-
-	switch parts[0] {
-	case TCP, UDP:
-		target.Protocol = parts[0]
-	default:
-		return target, fmt.Errorf("invalid protocol")
 	}
 
 	var err error
 
-	if target.LocalPort, err = parseNetworkPort(parts[1]); err != nil {
+	if target.LocalPort, err = parseNetworkPort(parts[0]); err != nil {
 		return target, fmt.Errorf("invalid local port: %w", err)
 	}
 
-	if target.Device = parts[2]; !isValidDeviceID(target.Device) {
-		return target, fmt.Errorf("invalid device")
+	target.RemoteHost = parts[1]
+
+	// Only localhost is supported as remote host at the moment.
+	// Once we roll out the new remote access solution, will allow any host in the same network.
+	if target.RemoteHost != "localhost" {
+		return target, fmt.Errorf("invalid remote host: only localhost is supported")
 	}
 
-	if target.RemotePort, err = parseNetworkPort(parts[3]); err != nil {
+	remotePort := parts[2]
+	if strings.HasSuffix(remotePort, "/udp") {
+		target.Protocol = UDP
+		remotePort = strings.TrimSuffix(remotePort, "/udp")
+	} else {
+		target.Protocol = TCP
+	}
+
+	if target.RemotePort, err = parseNetworkPort(remotePort); err != nil {
 		return target, fmt.Errorf("invalid remote port: %w", err)
 	}
 
 	return target, nil
+}
+
+// String returns the string representation of a remote access target.
+func (target RemoteAccessTarget) String() string {
+	base := fmt.Sprintf("%d:%s:%d", target.LocalPort, target.RemoteHost, target.RemotePort)
+
+	if target.Protocol == UDP {
+		return base + "/udp"
+	}
+
+	return base
 }
 
 // parseNetworkPort parses a network port string.

--- a/client/remote_access.go
+++ b/client/remote_access.go
@@ -33,7 +33,7 @@ type RemoteAccessTarget struct {
 	// Can be either "tcp" or "udp".
 	Protocol string
 
-	// RemoteHost is the host of the remote machine to which the loca port is forwarded.
+	// RemoteHost is the host of the remote machine to which the local port is forwarded.
 	RemoteHost string
 
 	// LocalPort is the port on the local machine to which the remote port is forwarded.

--- a/client/remote_access_test.go
+++ b/client/remote_access_test.go
@@ -33,73 +33,63 @@ func TestParseRemoteAccessTarget(t *testing.T) {
 	}{
 		{
 			name:         "valid tcp target",
-			targetString: "tcp:1:af973d5836408b20cf051342f1cbf75a1f9096385993f15a4645e4f75e75f288:2",
+			targetString: "1:localhost:2",
 			want: client.RemoteAccessTarget{
 				Protocol:   "tcp",
 				LocalPort:  1,
-				Device:     "af973d5836408b20cf051342f1cbf75a1f9096385993f15a4645e4f75e75f288",
+				RemoteHost: "localhost",
 				RemotePort: 2,
 			},
 		},
 		{
 			name:         "valid udp target",
-			targetString: "udp:1:af973d5836408b20cf051342f1cbf75a1f9096385993f15a4645e4f75e75f288:2",
+			targetString: "1:localhost:2/udp",
 			want: client.RemoteAccessTarget{
 				Protocol:   "udp",
 				LocalPort:  1,
-				Device:     "af973d5836408b20cf051342f1cbf75a1f9096385993f15a4645e4f75e75f288",
+				RemoteHost: "localhost",
 				RemotePort: 2,
 			},
 		},
 		{
 			name:         "invalid format",
-			targetString: "af973d5836408b20cf051342f1cbf75a1f9096385993f15a4645e4f75e75f288",
+			targetString: "localhost",
 			wantErr:      "invalid format",
 		},
 		{
-			name:         "unsupported protocol",
-			targetString: "x:1:af973d5836408b20cf051342f1cbf75a1f9096385993f15a4645e4f75e75f288:2",
-			wantErr:      "invalid protocol",
+			name:         "unsupported host",
+			targetString: "123:example.com:123",
+			wantErr:      "invalid remote host: only localhost is supported",
 		},
 		{
 			name:         "local port out of range",
-			targetString: "tcp:123456:af973d5836408b20cf051342f1cbf75a1f9096385993f15a4645e4f75e75f288:2",
+			targetString: "123456:localhost:2",
 			wantErr:      "invalid local port: invalid port number",
 		},
 		{
 			name:         "local port does not support service name",
-			targetString: "tcp:ssh:af973d5836408b20cf051342f1cbf75a1f9096385993f15a4645e4f75e75f288:2",
+			targetString: "ssh:localhost:2",
 			wantErr:      "invalid local port: invalid port number",
 		},
 		{
 			name:         "empty local port",
-			targetString: "tcp::af973d5836408b20cf051342f1cbf75a1f9096385993f15a4645e4f75e75f288:2",
+			targetString: ":localhost:2",
 			wantErr:      "invalid local port: empty port",
 		},
 		{
 			name:         "remote port out of range",
-			targetString: "tcp:1:af973d5836408b20cf051342f1cbf75a1f9096385993f15a4645e4f75e75f288:234567",
+			targetString: "1:localhost:234567",
 			wantErr:      "invalid remote port: invalid port number",
 		},
 		{
 			name:         "remote port does not support service name",
-			targetString: "tcp:1:af973d5836408b20cf051342f1cbf75a1f9096385993f15a4645e4f75e75f288:ssh",
+			targetString: "1:localhost:ssh",
 			wantErr:      "invalid remote port: invalid port number",
 		},
 		{
 			name:         "empty remote port",
-			targetString: "tcp:1:af973d5836408b20cf051342f1cbf75a1f9096385993f15a4645e4f75e75f288:",
+			targetString: "1:localhost:",
 			wantErr:      "invalid remote port: empty port",
-		},
-		{
-			name:         "invalid device ID length",
-			targetString: "tcp:1:abc:2",
-			wantErr:      "invalid device",
-		},
-		{
-			name:         "invalid device characters",
-			targetString: "tcp:1:xx973d5836408b20cf051342f1cbf75a1f9096385993f15a4645e4f75e75f288:2",
-			wantErr:      "invalid device",
 		},
 	}
 	for _, tt := range tests {

--- a/cmd/command.go
+++ b/cmd/command.go
@@ -53,9 +53,6 @@ type Option struct {
 	// If no value is set and Default is an empty string, Target won't be executed.
 	Default string
 
-	// Value of the Option after evaluating flags.
-	Value string
-
 	// Hidden if set, the option won't be returned in the help message.
 	// This is useful for internal options.
 	Hidden bool

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -20,21 +20,29 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/qbee-io/qbee-cli/client"
 )
 
 const (
-	connectTargetOption = "target"
+	connectDeviceOption = "device"
+	connectTargetOption = "tunnel"
 )
 
 var connectCommand = Command{
 	Description: "Connect to a device",
 	Options: []Option{
 		{
+			Name:     connectDeviceOption,
+			Short:    "d",
+			Help:     "Device ID (as Public Key Digest)",
+			Required: true,
+		},
+		{
 			Name:     connectTargetOption,
 			Short:    "t",
-			Help:     "Target defined as <proto>:<localPort>:<deviceID>:<remotePort>",
+			Help:     "Comma-separated targets definition <localPort>:<remoteHost>:<remotePort>[/udp]",
 			Required: true,
 		},
 	},
@@ -44,9 +52,19 @@ var connectCommand = Command{
 
 		ctx := context.Background()
 
-		target, err := client.ParseRemoteAccessTarget(opts[connectTargetOption])
-		if err != nil {
-			return fmt.Errorf("error parsing target: %w", err)
+		deviceID := opts[connectDeviceOption]
+		if !client.IsValidDeviceID(deviceID) {
+			return fmt.Errorf("invalid device ID %s", deviceID)
+		}
+
+		targets := make([]client.RemoteAccessTarget, 0)
+		for _, targetString := range strings.Split(opts[connectTargetOption], ",") {
+			target, err := client.ParseRemoteAccessTarget(targetString)
+			if err != nil {
+				return fmt.Errorf("error parsing target %s: %w", targetString, err)
+			}
+
+			targets = append(targets, target)
 		}
 
 		cli := client.New()
@@ -54,10 +72,10 @@ var connectCommand = Command{
 			cli = cli.WithBaseURL(baseURL)
 		}
 
-		if err = cli.Authenticate(ctx, email, password); err != nil {
+		if err := cli.Authenticate(ctx, email, password); err != nil {
 			return err
 		}
 
-		return cli.Connect(ctx, target)
+		return cli.Connect(ctx, deviceID, targets)
 	},
 }

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	connectDeviceOption = "device"
-	connectTargetOption = "tunnel"
+	connectTargetOption = "target"
 )
 
 var connectCommand = Command{


### PR DESCRIPTION
We want to align better with how targets are defined for SSH tunnels, so it's easier for users familiar with the concept to use this tool.