### PR TITLE
Introduce timestamp type

### DIFF
--- a/client/device_attributes.go
+++ b/client/device_attributes.go
@@ -16,6 +16,8 @@
 
 package client
 
+import "github.com/qbee-io/qbee-cli/client/types"
+
 // DeviceAttributes represents additional device attributes set for the device.
 type DeviceAttributes struct {
 	// DeviceName is the name of the device which is displayed in the UI (if set).
@@ -76,9 +78,9 @@ type DeviceAttributes struct {
 
 	// UpdatedAuto contains Unix timestamp of the last time the device attributes were updated by the platform.
 	// This is a read-only field.
-	UpdatedAuto int64 `json:"updated_auto,omitempty"`
+	UpdatedAuto types.Timestamp `json:"updated_auto,omitempty"`
 
 	// UpdatedUser contains Unix timestamp of the last time the device attributes were updated by a user.
 	// This is a read-only field.
-	UpdatedUser int64 `json:"updated_user,omitempty"`
+	UpdatedUser types.Timestamp `json:"updated_user,omitempty"`
 }

--- a/client/inventory.go
+++ b/client/inventory.go
@@ -24,6 +24,7 @@ import (
 	"net/url"
 
 	"github.com/qbee-io/qbee-cli/client/config"
+	"github.com/qbee-io/qbee-cli/client/types"
 )
 
 const deviceInventoryPath = "/api/v2/inventory"
@@ -144,8 +145,11 @@ type SystemInfo struct {
 	// RemoteAddress - remote client address from which the inventory was reported (e.g. "1.2.3.4").
 	RemoteAddress string `json:"remoteaddr"`
 
+	// LastPolicyUpdate - latest applied policy update timestamp (e.g. "1668156545")
+	LastPolicyUpdate types.Timestamp `json:"last_policy_update" bson:"last_policy_update"`
+
 	// LastConfigUpdate - unix timestamp of the last config update (e.g. "1586144402").
-	LastConfigUpdate string `json:"last_config_update"`
+	LastConfigUpdate types.Timestamp `json:"last_config_update"`
 
 	// LastConfigCommitID - last applied config commit SHA
 	// (e.g. "6c07b6d021a015329b1815ec954cca6d8c4973c3b574202401dad448e8cdd0f5").
@@ -174,13 +178,13 @@ type DeviceInventory struct {
 	ConfigPropagated bool `json:"config_propagated"`
 
 	// LastReported is the unix timestamp when the device checked-in with the platform.
-	LastReported int `json:"last_reported"`
+	LastReported types.Timestamp `json:"last_reported"`
 
 	// HeartbeatExpirationSoft is the unix timestamp when the device will be marked as delayed.
-	HeartbeatExpirationSoft int `json:"exp_soft"`
+	HeartbeatExpirationSoft types.Timestamp `json:"exp_soft"`
 
 	// HeartbeatExpirationHard is the unix timestamp when the device will be marked as offline.
-	HeartbeatExpirationHard int `json:"exp_hard"`
+	HeartbeatExpirationHard types.Timestamp `json:"exp_hard"`
 
 	// DeviceCommitSHA is the SHA of the commit that is currently running on the device.
 	DeviceCommitSHA string `json:"device_commit_sha"`

--- a/client/inventory.go
+++ b/client/inventory.go
@@ -146,7 +146,7 @@ type SystemInfo struct {
 	RemoteAddress string `json:"remoteaddr"`
 
 	// LastPolicyUpdate - latest applied policy update timestamp (e.g. "1668156545")
-	LastPolicyUpdate types.Timestamp `json:"last_policy_update" bson:"last_policy_update"`
+	LastPolicyUpdate types.Timestamp `json:"last_policy_update"`
 
 	// LastConfigUpdate - unix timestamp of the last config update (e.g. "1586144402").
 	LastConfigUpdate types.Timestamp `json:"last_config_update"`

--- a/client/types/timestamp.go
+++ b/client/types/timestamp.go
@@ -1,0 +1,75 @@
+// Copyright 2023 qbee.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+import (
+	"bytes"
+	"encoding/json"
+	"strconv"
+	"time"
+)
+
+// Timestamp is an int64-based type that allows to unmarshal also from string containing unix timestamp or date string.
+type Timestamp int64
+
+func parseTimestamp(s string) (Timestamp, error) {
+	if s == "" {
+		return 0, nil
+	}
+
+	i, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		timeValue, timeErr := time.Parse(time.ANSIC, s)
+		if timeErr != nil {
+			return 0, err
+		}
+
+		return Timestamp(timeValue.Unix()), nil
+	}
+
+	return Timestamp(i), nil
+}
+
+// UnmarshalJSON allows to unmarshal Int64String from string or int64.
+func (i64 *Timestamp) UnmarshalJSON(data []byte) error {
+	if bytes.HasPrefix(data, []byte(`"`)) {
+		var value string
+		var err error
+
+		if err = json.Unmarshal(data, &value); err != nil {
+			return err
+		}
+
+		*i64, err = parseTimestamp(value)
+
+		return err
+	}
+
+	var value int64
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+
+	*i64 = Timestamp(value)
+
+	return nil
+}
+
+// Time returns the time.Time value of the timestamp.
+func (i64 *Timestamp) Time() time.Time {
+	return time.Unix(int64(*i64), 0)
+}

--- a/client/types/timestamp_test.go
+++ b/client/types/timestamp_test.go
@@ -1,0 +1,68 @@
+// Copyright 2023 qbee.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestTimestamp_UnmarshalJSON(t *testing.T) {
+	type TestStruct struct {
+		Value Timestamp `json:"t"`
+	}
+
+	tests := []struct {
+		name     string
+		json     string
+		expected Timestamp
+	}{
+		{
+			name:     "undefined",
+			json:     `{}`,
+			expected: Timestamp(0),
+		},
+		{
+			name:     "from int",
+			json:     `{"t": 123}`,
+			expected: Timestamp(123),
+		},
+		{
+			name:     "from unix timestamp string",
+			json:     `{"t": "123"}`,
+			expected: Timestamp(123),
+		},
+		{
+			name:     "from date string",
+			json:     `{"t": "Mon Jan  2 15:04:05 2006"}`,
+			expected: Timestamp(1136214245),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := TestStruct{}
+
+			if err := json.Unmarshal([]byte(tt.json), &got); err != nil {
+				t.Fatalf("UnmarshalJSON() error = %v", err)
+			}
+
+			if got.Value != tt.expected {
+				t.Errorf("UnmarshalJSON() got = %v, want %v", got.Value, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change allows for easier use of timestamp fields (especially that some of them are returned as text from the API).
Also adding the misssing `LastPolicyUpdate` field to the system info struct.