### PR TITLE
DEV-1856: Allow stdio as local port

### DIFF
--- a/client/connect.go
+++ b/client/connect.go
@@ -162,7 +162,7 @@ func (cli *Client) GetRemoteAccessToken(ctx context.Context, req RemoteAccessTok
 func (cli *Client) Connect(ctx context.Context, deviceID string, targets []RemoteAccessTarget) error {
 	ports := make([]string, len(targets))
 	for _, target := range targets {
-		ports = append(ports, fmt.Sprintf("%s:%d", target.Protocol, target.RemotePort))
+		ports = append(ports, fmt.Sprintf("%s:%s", target.Protocol, target.RemotePort))
 	}
 
 	remoteAccessTokenRequest := RemoteAccessTokenRequest{

--- a/client/remote_access.go
+++ b/client/remote_access.go
@@ -42,7 +42,7 @@ type RemoteAccessTarget struct {
 	LocalPort string
 
 	// RemotePort is the port on the remote machine to which the local port is forwarded.
-	RemotePort uint16
+	RemotePort string
 }
 
 // IsValidDeviceID checks if the provided device ID is valid.
@@ -77,7 +77,7 @@ func ParseRemoteAccessTarget(targetString string) (RemoteAccessTarget, error) {
 
 	var err error
 
-	if target.LocalPort, err = parseLocalNetworkPort(parts[0]); err != nil {
+	if target.LocalPort, err = parseNetworkPort(parts[0]); err != nil {
 		return target, fmt.Errorf("invalid local port: %w", err)
 	}
 
@@ -97,7 +97,7 @@ func ParseRemoteAccessTarget(targetString string) (RemoteAccessTarget, error) {
 		target.Protocol = TCP
 	}
 
-	if target.RemotePort, err = parseRemoteNetworkPort(remotePort); err != nil {
+	if target.RemotePort, err = parseNetworkPort(remotePort); err != nil {
 		return target, fmt.Errorf("invalid remote port: %w", err)
 	}
 
@@ -106,7 +106,7 @@ func ParseRemoteAccessTarget(targetString string) (RemoteAccessTarget, error) {
 
 // String returns the string representation of a remote access target.
 func (target RemoteAccessTarget) String() string {
-	base := fmt.Sprintf("%s:%s:%d", target.LocalPort, target.RemoteHost, target.RemotePort)
+	base := fmt.Sprintf("%s:%s:%s", target.LocalPort, target.RemoteHost, target.RemotePort)
 
 	if target.Protocol == UDP {
 		return base + "/udp"
@@ -115,10 +115,10 @@ func (target RemoteAccessTarget) String() string {
 	return base
 }
 
-// parseLocalNetworkPort parses a network port string and accepts either a port number or "stdio".
-func parseLocalNetworkPort(portString string) (string, error) {
+// parseNetworkPort parses a network port string and accepts either a port number or "stdio".
+func parseNetworkPort(portString string) (string, error) {
 	if portString == "" {
-		return "0", fmt.Errorf("empty port")
+		return "", fmt.Errorf("empty port")
 	}
 
 	if portString == "stdio" {
@@ -127,22 +127,8 @@ func parseLocalNetworkPort(portString string) (string, error) {
 
 	_, err := strconv.ParseUint(portString, 10, 16)
 	if err != nil {
-		return "0", fmt.Errorf("invalid port number")
+		return "", fmt.Errorf("invalid port number")
 	}
 
 	return portString, nil
-}
-
-// parseRemoteNetworkPort parses a network port string and accepts only port numbers
-func parseRemoteNetworkPort(portString string) (uint16, error) {
-	if portString == "" {
-		return 0, fmt.Errorf("empty port")
-	}
-
-	portUint, err := strconv.ParseUint(portString, 10, 16)
-	if err != nil {
-		return 0, fmt.Errorf("invalid port number")
-	}
-
-	return uint16(portUint), nil
 }

--- a/client/remote_access.go
+++ b/client/remote_access.go
@@ -39,7 +39,7 @@ type RemoteAccessTarget struct {
 
 	// LocalPort is the port on the local machine to which the remote port is forwarded.
 	// If set to 0, a random port will be chosen.
-	LocalPort uint16
+	LocalPort string
 
 	// RemotePort is the port on the remote machine to which the local port is forwarded.
 	RemotePort uint16
@@ -77,7 +77,7 @@ func ParseRemoteAccessTarget(targetString string) (RemoteAccessTarget, error) {
 
 	var err error
 
-	if target.LocalPort, err = parseNetworkPort(parts[0]); err != nil {
+	if target.LocalPort, err = parseLocalNetworkPort(parts[0]); err != nil {
 		return target, fmt.Errorf("invalid local port: %w", err)
 	}
 
@@ -97,7 +97,7 @@ func ParseRemoteAccessTarget(targetString string) (RemoteAccessTarget, error) {
 		target.Protocol = TCP
 	}
 
-	if target.RemotePort, err = parseNetworkPort(remotePort); err != nil {
+	if target.RemotePort, err = parseRemoteNetworkPort(remotePort); err != nil {
 		return target, fmt.Errorf("invalid remote port: %w", err)
 	}
 
@@ -106,7 +106,7 @@ func ParseRemoteAccessTarget(targetString string) (RemoteAccessTarget, error) {
 
 // String returns the string representation of a remote access target.
 func (target RemoteAccessTarget) String() string {
-	base := fmt.Sprintf("%d:%s:%d", target.LocalPort, target.RemoteHost, target.RemotePort)
+	base := fmt.Sprintf("%s:%s:%d", target.LocalPort, target.RemoteHost, target.RemotePort)
 
 	if target.Protocol == UDP {
 		return base + "/udp"
@@ -115,8 +115,26 @@ func (target RemoteAccessTarget) String() string {
 	return base
 }
 
-// parseNetworkPort parses a network port string.
-func parseNetworkPort(portString string) (uint16, error) {
+// parseLocalNetworkPort parses a network port string and accepts either a port number or "stdio".
+func parseLocalNetworkPort(portString string) (string, error) {
+	if portString == "" {
+		return "0", fmt.Errorf("empty port")
+	}
+
+	if portString == "stdio" {
+		return portString, nil
+	}
+
+	_, err := strconv.ParseUint(portString, 10, 16)
+	if err != nil {
+		return "0", fmt.Errorf("invalid port number")
+	}
+
+	return portString, nil
+}
+
+// parseRemoteNetworkPort parses a network port string and accepts only port numbers
+func parseRemoteNetworkPort(portString string) (uint16, error) {
 	if portString == "" {
 		return 0, fmt.Errorf("empty port")
 	}

--- a/client/remote_access.go
+++ b/client/remote_access.go
@@ -38,7 +38,6 @@ type RemoteAccessTarget struct {
 	RemoteHost string
 
 	// LocalPort is the port on the local machine to which the remote port is forwarded.
-	// If set to 0, a random port will be chosen.
 	LocalPort string
 
 	// RemotePort is the port on the remote machine to which the local port is forwarded.

--- a/client/remote_access.go
+++ b/client/remote_access.go
@@ -76,7 +76,7 @@ func ParseRemoteAccessTarget(targetString string) (RemoteAccessTarget, error) {
 
 	var err error
 
-	if target.LocalPort, err = parseNetworkPort(parts[0]); err != nil {
+	if target.LocalPort, err = parseLocalNetworkPort(parts[0]); err != nil {
 		return target, fmt.Errorf("invalid local port: %w", err)
 	}
 
@@ -114,14 +114,23 @@ func (target RemoteAccessTarget) String() string {
 	return base
 }
 
-// parseNetworkPort parses a network port string and accepts either a port number or "stdio".
+// parseLocalNetworkPort parses a network port string and accepts either a port number or "stdio".
+func parseLocalNetworkPort(portString string) (string, error) {
+	if portString == "stdio" {
+		return portString, nil
+	}
+
+	if _, err := parseNetworkPort(portString); err != nil {
+		return "", err
+	}
+
+	return portString, nil
+}
+
+// parseNetworkPort parses a network port string and accepts a port number.
 func parseNetworkPort(portString string) (string, error) {
 	if portString == "" {
 		return "", fmt.Errorf("empty port")
-	}
-
-	if portString == "stdio" {
-		return portString, nil
 	}
 
 	_, err := strconv.ParseUint(portString, 10, 16)

--- a/client/remote_access_test.go
+++ b/client/remote_access_test.go
@@ -52,7 +52,7 @@ func TestParseRemoteAccessTarget(t *testing.T) {
 			},
 		},
 		{
-			name:         "valid tcp target",
+			name:         "valid stdio target",
 			targetString: "stdio:localhost:2",
 			want: client.RemoteAccessTarget{
 				Protocol:   "tcp",
@@ -62,7 +62,7 @@ func TestParseRemoteAccessTarget(t *testing.T) {
 			},
 		},
 		{
-			name:         "valid udp target",
+			name:         "valid stdio target",
 			targetString: "stdio:localhost:2/udp",
 			want: client.RemoteAccessTarget{
 				Protocol:   "udp",

--- a/client/remote_access_test.go
+++ b/client/remote_access_test.go
@@ -36,7 +36,7 @@ func TestParseRemoteAccessTarget(t *testing.T) {
 			targetString: "1:localhost:2",
 			want: client.RemoteAccessTarget{
 				Protocol:   "tcp",
-				LocalPort:  1,
+				LocalPort:  "1",
 				RemoteHost: "localhost",
 				RemotePort: 2,
 			},
@@ -46,7 +46,27 @@ func TestParseRemoteAccessTarget(t *testing.T) {
 			targetString: "1:localhost:2/udp",
 			want: client.RemoteAccessTarget{
 				Protocol:   "udp",
-				LocalPort:  1,
+				LocalPort:  "1",
+				RemoteHost: "localhost",
+				RemotePort: 2,
+			},
+		},
+		{
+			name:         "valid tcp target",
+			targetString: "stdio:localhost:2",
+			want: client.RemoteAccessTarget{
+				Protocol:   "tcp",
+				LocalPort:  "stdio",
+				RemoteHost: "localhost",
+				RemotePort: 2,
+			},
+		},
+		{
+			name:         "valid udp target",
+			targetString: "stdio:localhost:2/udp",
+			want: client.RemoteAccessTarget{
+				Protocol:   "udp",
+				LocalPort:  "stdio",
 				RemoteHost: "localhost",
 				RemotePort: 2,
 			},

--- a/client/remote_access_test.go
+++ b/client/remote_access_test.go
@@ -38,7 +38,7 @@ func TestParseRemoteAccessTarget(t *testing.T) {
 				Protocol:   "tcp",
 				LocalPort:  "1",
 				RemoteHost: "localhost",
-				RemotePort: 2,
+				RemotePort: "2",
 			},
 		},
 		{
@@ -48,7 +48,7 @@ func TestParseRemoteAccessTarget(t *testing.T) {
 				Protocol:   "udp",
 				LocalPort:  "1",
 				RemoteHost: "localhost",
-				RemotePort: 2,
+				RemotePort: "2",
 			},
 		},
 		{
@@ -58,7 +58,7 @@ func TestParseRemoteAccessTarget(t *testing.T) {
 				Protocol:   "tcp",
 				LocalPort:  "stdio",
 				RemoteHost: "localhost",
-				RemotePort: 2,
+				RemotePort: "2",
 			},
 		},
 		{
@@ -68,7 +68,7 @@ func TestParseRemoteAccessTarget(t *testing.T) {
 				Protocol:   "udp",
 				LocalPort:  "stdio",
 				RemoteHost: "localhost",
-				RemotePort: 2,
+				RemotePort: "2",
 			},
 		},
 		{

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ import (
 
 func main() {
 	if err := cmd.Main.Execute(os.Args[1:], nil); err != nil {
-		fmt.Printf("Error: %s\n", err)
+		fmt.Fprintf(os.Stderr, "qbee-cli error: %s\n", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
chisel can be embedded in ssh config by defining stdio:<host>:<port>

https://github.com/jpillora/chisel/blob/master/main.go#L352-L357

qbee-cli will also need to accept stdio if we want to use it in ProxyCommand in ssh_config

```
host qbee-cli+*
  User qbee
  ProxyCommand qbee-cli connect -d $(echo %h | sed 's/qbee-cli+//') -t stdio:localhost:22
```

```
$ ssh qbee-cli+cf0b2360237e1975c57af34ba74baef2eaaea2733fa5e1b10bfa05a514cb9a01
2023/11/16 12:01:15 client: Connecting to wss://www.app.qbee-dev.qbee.io:443/qbee-connect/1/
2023/11/16 12:01:15 client: Connected (Latency 41.990683ms)
qbee@qbee-cli+cf0b2360237e1975c57af34ba74baef2eaaea2733fa5e1b10bfa05a514cb9a01's password: 
Linux qbeedemo 6.1.0-13-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.55-1 (2023-09-29) x86_64

The programs included with the Debian GNU/Linux system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
permitted by applicable law.
Last login: Thu Nov 16 10:53:07 2023

```