### PR TITLE
DEV-1955: Connect to multiple devices + targets definition via config file.

### DIFF
--- a/client/remote_access.go
+++ b/client/remote_access.go
@@ -41,16 +41,16 @@ type RemoteAccessConnection struct {
 type RemoteAccessTarget struct {
 	// Protocol is the protocol used for the remote access.
 	// Can be either "tcp" or "udp".
-	Protocol string `json:"protocol"`
+	Protocol string
 
 	// RemoteHost is the host of the remote machine to which the local port is forwarded.
-	RemoteHost string `json:"remote_host"`
+	RemoteHost string
 
 	// LocalPort is the port on the local machine to which the remote port is forwarded.
-	LocalPort string `json:"local_port"`
+	LocalPort string
 
 	// RemotePort is the port on the remote machine to which the local port is forwarded.
-	RemotePort string `json:"remote_port"`
+	RemotePort string
 }
 
 // IsValidDeviceID checks if the provided device ID is valid.

--- a/client/remote_access.go
+++ b/client/remote_access.go
@@ -28,20 +28,29 @@ const (
 	UDP = "udp"
 )
 
+// RemoteAccessConnection defines a remote access connection.
+type RemoteAccessConnection struct {
+	// DeviceID is the device ID of the device to which the remote access connection belongs.
+	DeviceID string `json:"device_id"`
+
+	// Targets is a list of remote access targets.
+	Targets []string `json:"targets"`
+}
+
 // RemoteAccessTarget defines
 type RemoteAccessTarget struct {
 	// Protocol is the protocol used for the remote access.
 	// Can be either "tcp" or "udp".
-	Protocol string
+	Protocol string `json:"protocol"`
 
 	// RemoteHost is the host of the remote machine to which the local port is forwarded.
-	RemoteHost string
+	RemoteHost string `json:"remote_host"`
 
 	// LocalPort is the port on the local machine to which the remote port is forwarded.
-	LocalPort string
+	LocalPort string `json:"local_port"`
 
 	// RemotePort is the port on the remote machine to which the local port is forwarded.
-	RemotePort string
+	RemotePort string `json:"remote_port"`
 }
 
 // IsValidDeviceID checks if the provided device ID is valid.

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -50,9 +50,6 @@ const (
 //   }
 // ]
 
-// RemoteAccessTargets is a list of remote access targets.
-var RemoteAccessTargets = make([]client.RemoteAccessConnection, 0)
-
 var connectCommand = Command{
 	Description: "Connect to a device",
 	Options: []Option{
@@ -74,19 +71,6 @@ var connectCommand = Command{
 	},
 	OptionsHandler: func(opts Options) error {
 		if opts[connectConfigFileOption] != "" {
-			configBytes, err := os.ReadFile(opts[connectConfigFileOption])
-			if err != nil {
-				return fmt.Errorf("error reading config file: %w", err)
-			}
-
-			err = json.Unmarshal(configBytes, &RemoteAccessTargets)
-			if err != nil {
-				return fmt.Errorf("error parsing config file: %w", err)
-			}
-
-			if len(RemoteAccessTargets) == 0 {
-				return fmt.Errorf("no connections defined in config file")
-			}
 			return nil
 		}
 		if opts[connectDeviceOption] == "" {
@@ -95,10 +79,6 @@ var connectCommand = Command{
 		if opts[connectTargetOption] == "" {
 			return fmt.Errorf("missing target")
 		}
-		RemoteAccessTargets = append(RemoteAccessTargets, client.RemoteAccessConnection{
-			DeviceID: opts[connectDeviceOption],
-			Targets:  strings.Split(opts[connectTargetOption], ","),
-		})
 		return nil
 	},
 	Target: func(opts Options) error {
@@ -106,26 +86,6 @@ var connectCommand = Command{
 		password := os.Getenv("QBEE_PASSWORD")
 
 		ctx := context.Background()
-
-		remoteAccessMap := make(map[string][]client.RemoteAccessTarget, 0)
-
-		for _, target := range RemoteAccessTargets {
-			if !client.IsValidDeviceID(target.DeviceID) {
-				return fmt.Errorf("invalid device ID %s", target.DeviceID)
-			}
-
-			targets := make([]client.RemoteAccessTarget, 0)
-			for _, targetString := range target.Targets {
-				target, err := client.ParseRemoteAccessTarget(targetString)
-				if err != nil {
-					return fmt.Errorf("error parsing target %s: %w", targetString, err)
-				}
-
-				targets = append(targets, target)
-			}
-
-			remoteAccessMap[target.DeviceID] = targets
-		}
 
 		cli := client.New()
 		if baseURL, ok := os.LookupEnv("QBEE_BASEURL"); ok {
@@ -135,6 +95,30 @@ var connectCommand = Command{
 		if err := cli.Authenticate(ctx, email, password); err != nil {
 			return err
 		}
-		return cli.Connect(ctx, remoteAccessMap)
+
+		remoteAccessTargets := make([]client.RemoteAccessConnection, 0)
+
+		if opts[connectConfigFileOption] != "" {
+			configBytes, err := os.ReadFile(opts[connectConfigFileOption])
+			if err != nil {
+				return fmt.Errorf("error reading config file: %w", err)
+			}
+
+			if err := json.Unmarshal(configBytes, &remoteAccessTargets); err != nil {
+				return fmt.Errorf("error parsing config file: %w", err)
+			}
+
+			if len(remoteAccessTargets) == 0 {
+				return fmt.Errorf("no connections defined in config file")
+			}
+		} else {
+			remoteAccessTargets = append(remoteAccessTargets, client.RemoteAccessConnection{
+				DeviceID: opts[connectDeviceOption],
+				Targets:  strings.Split(opts[connectTargetOption], ","),
+			})
+		}
+		cli.ConnectMulti(ctx, remoteAccessTargets)
+		return nil
+
 	},
 }

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -73,12 +73,15 @@ var connectCommand = Command{
 		if opts[connectConfigFileOption] != "" {
 			return nil
 		}
+
 		if opts[connectDeviceOption] == "" {
 			return fmt.Errorf("missing device ID")
 		}
+
 		if opts[connectTargetOption] == "" {
 			return fmt.Errorf("missing target")
 		}
+
 		return nil
 	},
 	Target: func(opts Options) error {

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -32,6 +32,25 @@ const (
 	connectConfigFileOption = "config"
 )
 
+// Example config file:
+// [
+//   {
+//     "device_id": "2c40ccd4f8587e3e98d66e9092db4e8b0827906cb79c764b77cb2090b9acb7c8",
+//     "targets": [
+//       "5050:localhost:22",
+//       "5151:localhost:80"
+//     ]
+//   },
+//   {
+//     "device_id": "09790f5388e3180793192fa6952e4c13c25bee650ddbf707d2764ac349d54046",
+//     "targets": [
+//       "8080:localhost:22",
+//       "8081:localhost:80"
+//     ]
+//   }
+// ]
+
+// RemoteAccessTargets is a list of remote access targets.
 var RemoteAccessTargets = make([]client.RemoteAccessConnection, 0)
 
 var connectCommand = Command{


### PR DESCRIPTION
Read remote access connections from a config file and set run them in separate go routines.
Accept connection failures for one or more targets.