### PR TITLE
Retract legacy versions of go.qbee.io/client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,13 @@ module go.qbee.io/client
 
 go 1.21
 
+// retract lagecy version of the module
+retract (
+	v1.2023.49-1
+	v1.2023.49
+	v1.2024.4
+)
+
 require (
 	github.com/jpillora/chisel v1.9.1
 	golang.org/x/net v0.17.0

--- a/go.mod
+++ b/go.mod
@@ -2,12 +2,8 @@ module go.qbee.io/client
 
 go 1.21
 
-// retract lagecy version of the module
-retract (
-	v1.2023.49-1
-	v1.2023.49
-	v1.2024.4
-)
+// retract lagecy versions of the module
+retract [v1.2023.0, v1.2024.4]
 
 require (
 	github.com/jpillora/chisel v1.9.1

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module go.qbee.io/client
 
 go 1.21
 
-// retract lagecy versions of the module
+// retract legacy versions of the module
 retract [v1.2023.0, v1.2024.4]
 
 require (


### PR DESCRIPTION
The v1.2023.XX notation looks bad, I think we can do better with v1.24.4, where 24 is the last two digits of 2024, and 4 is the 4th week. This PR retracts already published versions.