### PR TITLE
Add an optional localHost component in the connect command's target definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ qbee-cli connect -d <deviceID> -t <target>[,<target> ...]
 
 Where:
 - `deviceID` identifies to which device we want to connect (public key digest)
-- `target` defines a singe port forwarding target as `<localPort>:<remoteHost>:<remotePort>`
+- `target` defines a singe port forwarding target as `[<localHost>:]<localPort>:<remoteHost>:<remotePort>`
+- `localHost` is optional and defaults to _127.0.0.1_ to only listen on the loopback interface
 - `localPort` is the local port on which tunnel will listen for connections/packets
 - `remoteHost` must be set to _localhost_
 - `remotePort` is the remote port on which tunnel will connect to on the device

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ qbee-cli connect -d <deviceID> -t <target>[,<target> ...]
 Where:
 - `deviceID` identifies to which device we want to connect (public key digest)
 - `target` defines a singe port forwarding target as `[<localHost>:]<localPort>:<remoteHost>:<remotePort>`
-- `localHost` is optional and defaults to _127.0.0.1_ to only listen on the loopback interface
+- `localHost` is optional and defaults to _localhost_ to only listen on the loopback interface
 - `localPort` is the local port on which tunnel will listen for connections/packets
 - `remoteHost` must be set to _localhost_
 - `remotePort` is the remote port on which tunnel will connect to on the device

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -62,7 +62,7 @@ var connectCommand = Command{
 		{
 			Name:  connectTargetOption,
 			Short: "t",
-			Help:  "Comma-separated targets definition <localPort>:<remoteHost>:<remotePort>[/udp]",
+			Help:  "Comma-separated targets definition [<localHost:]<localPort>:<remoteHost>:<remotePort>[/udp]",
 		},
 		{
 			Name:  connectConfigFileOption,

--- a/connect.go
+++ b/connect.go
@@ -287,7 +287,7 @@ func (cli *Client) connect(ctx context.Context, deviceUUID, edgeHost string, tar
 			return fmt.Errorf("stdio is only supported for single target connections")
 		}
 
-		localHostPort := fmt.Sprintf("localhost:%s", target.LocalPort)
+		localHostPort := fmt.Sprintf("%s:%s", target.LocalHost, target.LocalPort)
 		remoteHostPort := fmt.Sprintf("%s:%s", target.RemoteHost, target.RemotePort)
 
 		switch target.Protocol {

--- a/remote_access.go
+++ b/remote_access.go
@@ -95,7 +95,7 @@ func ParseRemoteAccessTarget(targetString string) (RemoteAccessTarget, error) {
 	var remotePort string
 
 	if len(parts) == 3 {
-		localHost = "127.0.0.1"
+		localHost = "localhost"
 		localPort = parts[0]
 		remoteHost = parts[1]
 		remotePort = parts[2]

--- a/remote_access_test.go
+++ b/remote_access_test.go
@@ -36,7 +36,7 @@ func TestParseRemoteAccessTarget(t *testing.T) {
 			targetString: "1:localhost:2",
 			want: client.RemoteAccessTarget{
 				Protocol:   "tcp",
-				LocalHost:  "127.0.0.1",
+				LocalHost:  "localhost",
 				LocalPort:  "1",
 				RemoteHost: "localhost",
 				RemotePort: "2",
@@ -58,7 +58,7 @@ func TestParseRemoteAccessTarget(t *testing.T) {
 			targetString: "1:localhost:2/udp",
 			want: client.RemoteAccessTarget{
 				Protocol:   "udp",
-				LocalHost:  "127.0.0.1",
+				LocalHost:  "localhost",
 				LocalPort:  "1",
 				RemoteHost: "localhost",
 				RemotePort: "2",
@@ -69,7 +69,7 @@ func TestParseRemoteAccessTarget(t *testing.T) {
 			targetString: "stdio:localhost:2",
 			want: client.RemoteAccessTarget{
 				Protocol:   "tcp",
-				LocalHost:  "127.0.0.1",
+				LocalHost:  "localhost",
 				LocalPort:  "stdio",
 				RemoteHost: "localhost",
 				RemotePort: "2",
@@ -80,7 +80,7 @@ func TestParseRemoteAccessTarget(t *testing.T) {
 			targetString: "stdio:localhost:2/udp",
 			want: client.RemoteAccessTarget{
 				Protocol:   "udp",
-				LocalHost:  "127.0.0.1",
+				LocalHost:  "localhost",
 				LocalPort:  "stdio",
 				RemoteHost: "localhost",
 				RemotePort: "2",

--- a/remote_access_test.go
+++ b/remote_access_test.go
@@ -36,6 +36,18 @@ func TestParseRemoteAccessTarget(t *testing.T) {
 			targetString: "1:localhost:2",
 			want: client.RemoteAccessTarget{
 				Protocol:   "tcp",
+				LocalHost:  "127.0.0.1",
+				LocalPort:  "1",
+				RemoteHost: "localhost",
+				RemotePort: "2",
+			},
+		},
+		{
+			name:         "valid tcp target with custom local host",
+			targetString: "0.0.0.0:1:localhost:2",
+			want: client.RemoteAccessTarget{
+				Protocol:   "tcp",
+				LocalHost:  "0.0.0.0",
 				LocalPort:  "1",
 				RemoteHost: "localhost",
 				RemotePort: "2",
@@ -46,6 +58,7 @@ func TestParseRemoteAccessTarget(t *testing.T) {
 			targetString: "1:localhost:2/udp",
 			want: client.RemoteAccessTarget{
 				Protocol:   "udp",
+				LocalHost:  "127.0.0.1",
 				LocalPort:  "1",
 				RemoteHost: "localhost",
 				RemotePort: "2",
@@ -56,6 +69,7 @@ func TestParseRemoteAccessTarget(t *testing.T) {
 			targetString: "stdio:localhost:2",
 			want: client.RemoteAccessTarget{
 				Protocol:   "tcp",
+				LocalHost:  "127.0.0.1",
 				LocalPort:  "stdio",
 				RemoteHost: "localhost",
 				RemotePort: "2",
@@ -66,6 +80,7 @@ func TestParseRemoteAccessTarget(t *testing.T) {
 			targetString: "stdio:localhost:2/udp",
 			want: client.RemoteAccessTarget{
 				Protocol:   "udp",
+				LocalHost:  "127.0.0.1",
 				LocalPort:  "stdio",
 				RemoteHost: "localhost",
 				RemotePort: "2",


### PR DESCRIPTION
If you want to use the Qbee CLI as a proxy solution for other applications which do not run on the same network, like a docker container, you need to be able to bind the connect command to another host than the default `localhost` - such as `0.0.0.0` to listen on all interfaces.

This PR adds an optional component to the connect command to support this.

Usage examples:
- `qbee-cli connect -d <device-id> -t 8080:localhost:8080` to bind local port 8080 to port 8080 of the given device. This will only listen on the loopback interface, and not be available from other hosts or from outside a Docker container the Qbee CLI may be running in (no changes compared to existing behaviour).
- `qbee-cli connect -d <device-id> -t 0.0.0.0:8080:localhost:8080` to bind local port 8080 to port 8080 of the given device, listening publically. 