### PR TITLE
Add support for 2FA codes through environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,11 @@ go build -o qbee-cli ./cmd
 
 ## Providing credentials
 
-Currently, the only way to provide credentials is through environmental variables: `QBEE_EMAIL` & `QBEE_PASSWORD`.
+Currently, the only way to provide credentials is through environmental variables: `QBEE_EMAIL` & `QBEE_PASSWORD`. 
 
-If the user account associated with the email requires two-factor authentication, the tool will return an error, as we currently don't support it. In that case, please consider creating a user with limited access and separate credentials which don't required two-factor authentication.
+If your account is configured with two-factor authentication, you will either be prompted for which of your configured
+2FA providers you want to use, or you can set the `QBEE_2FA_CODE` environment variable to provide a code for the 
+Google provider directly.
 
 Please remember to rotate your credentials regularly.
 


### PR DESCRIPTION
This PR adds support for a 3rd authentication environment variable, `QBEE_2FA_CODE`. If provided, it will be used as a Google authentication code for the 2FA process, rather than requiring interactive user input.

This helps use the qbee-cli in scripts (in my case, shorthands to connect to a device by its hostname instead of node_id) without having to make your account less secure by removing 2FA.