### PR TITLE
Add missing GitHub workflow permissions

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -1,4 +1,6 @@
 name: static-checks
+permissions:
+  contents: read
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/qbee-io/qbee-cli/security/code-scanning/1](https://github.com/qbee-io/qbee-cli/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow to explicitly define the least privileges required for the tasks. Since the workflow primarily involves testing and linting code, it does not require write access to the repository. The `contents: read` permission is sufficient for the `actions/checkout@v4` step, and no additional permissions are needed for the other steps.

The `permissions` block should be added at the root level of the workflow to apply to all jobs, as none of the jobs require elevated permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
