### PR TITLE
Upgrade go from 1.23 -> 1.24

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,13 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: 1.23.10
+          go-version: 1.24.5
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: v1.64.5
-          only-new-issues: true
-          skip-save-cache: true
+          version: v2.1

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -13,9 +13,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.23.10
+          go-version: 1.24.5
       - name: Build and test
         env:
           QBEE_EMAIL: ${{ secrets.QBEE_API_USER }}
@@ -25,7 +25,7 @@ jobs:
       - id: govulncheck
         uses: golang/govulncheck-action@v1
         with:
-          go-version-input: 1.23.10
+          go-version-input: 1.24.5
           go-package: ./...
       - name: golint
         run: go run golang.org/x/lint/golint@latest ./...

--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,13 @@
 module go.qbee.io/client
 
-go 1.23.0
+go 1.24.0
 
-toolchain go1.23.10
+toolchain go1.24.5
 
 require (
 	github.com/jpillora/chisel v1.10.1
 	github.com/xtaci/smux v1.5.34
-	go.qbee.io/transport v1.25.12
+	go.qbee.io/transport v1.25.28
 	golang.org/x/net v0.42.0
 	golang.org/x/term v0.33.0
 )

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/jpillora/sizestr v1.0.0 h1:4tr0FLxs1Mtq3TnsLDV+GYUWG7Q26a6s+tV5Zfw2yg
 github.com/jpillora/sizestr v1.0.0/go.mod h1:bUhLv4ctkknatr6gR42qPxirmd5+ds1u7mzD+MZ33f0=
 github.com/xtaci/smux v1.5.34 h1:OUA9JaDFHJDT8ZT3ebwLWPAgEfE6sWo2LaTy3anXqwg=
 github.com/xtaci/smux v1.5.34/go.mod h1:OMlQbT5vcgl2gb49mFkYo6SMf+zP3rcjcwQz7ZU7IGY=
-go.qbee.io/transport v1.25.12 h1:MhQaLcV1fYVJHysC3jywWzk44vGP45sZoXJ339iGrlw=
-go.qbee.io/transport v1.25.12/go.mod h1:CnCOkjNyL0qfF3e6jaeXUtlCKxDxFEpc3Un+sFlZm9Y=
+go.qbee.io/transport v1.25.28 h1:S6X91ORNaRrPsNn3x80gQWAnX4jIyVXG76R8u6dLkKw=
+go.qbee.io/transport v1.25.28/go.mod h1:SBtAKI5/BjXrXYGRDT04gSjyZxQiuvRApSDeFWeelh4=
 golang.org/x/crypto v0.40.0 h1:r4x+VvoG5Fm+eJcxMaY8CQM7Lb0l1lsmjGBQ6s8BfKM=
 golang.org/x/crypto v0.40.0/go.mod h1:Qr1vMER5WyS2dfPHAlsOj01wgLbsyWtFn/aY+5+ZdxY=
 golang.org/x/net v0.42.0 h1:jzkYrhi3YQWD6MLBJcsklgQsoAcw89EcZbJw8Z614hs=


### PR DESCRIPTION
This pull request updates Go-related dependencies and configurations across the project to use newer versions, ensuring compatibility and leveraging improvements in the Go ecosystem. The updates include changes to workflow files and the `go.mod` file.

### Workflow Updates:
* [`.github/workflows/golangci-lint.yml`](diffhunk://#diff-d9a956120ac84289d2650137f64bd8f0893331de05e44cc41899dd984c9e0d48L19-R26): Updated `actions/setup-go` to v5, Go version to 1.24.5, and `golangci-lint-action` to v8 with version v2.1. These changes modernize the linting workflow.
* [`.github/workflows/pr-test.yml`](diffhunk://#diff-cf34a98fd25d1698b625c9a988868d4cef5036692a76d1e28dc5aa42be237b9eL16-R18): Updated `actions/setup-go` to v5 and Go version to 1.24.5 in multiple steps, including the `govulncheck` step. This ensures consistency across the workflows. [[1]](diffhunk://#diff-cf34a98fd25d1698b625c9a988868d4cef5036692a76d1e28dc5aa42be237b9eL16-R18) [[2]](diffhunk://#diff-cf34a98fd25d1698b625c9a988868d4cef5036692a76d1e28dc5aa42be237b9eL28-R28)

### Dependency Updates:
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R10): Updated Go version to 1.24.0, toolchain to 1.24.5, and dependency `go.qbee.io/transport` to v1.25.28. These updates align the project with the latest Go standards and improve dependency management.