### PR TITLE
Use the QBEE_BASEURL env var for the login command

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ export QBEE_2FA_CODE=123456
 qbee-cli login
 ```
 
+If you need to authenticate against a different qbee.io instance, you can set the `QBEE_BASEURL` environment variable:
+
+```shell
+export QBEE_EMAIL=alice@example.com
+export QBEE_PASSWORD=secret
+export QBEE_BASEURL=https://www.app.qbee.example.com
+qbee-cli login
+```
+
 ### 3. Authentication Token (QBEE_TOKEN)
 
 For automated workflows and multiple command executions, you can use authentication tokens. First, obtain a token using the `--print-token` flag:

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -51,7 +51,8 @@ var loginCommand = Command{
 		// Check for environment variables first
 		email := os.Getenv("QBEE_EMAIL")
 		password := os.Getenv("QBEE_PASSWORD")
-		
+		baseURL := os.Getenv("QBEE_BASEURL")
+
 		// Use command line options if environment variables are not set
 		if email == "" {
 			email = opts[loginUserEmail]
@@ -59,8 +60,9 @@ var loginCommand = Command{
 		if password == "" {
 			password = opts[loginUserPassword]
 		}
-		
-		baseURL := opts[loginBaseURL]
+		if baseURL == "" {
+			baseURL = opts[loginBaseURL]
+		}
 
 		// Validate that we have required information
 		if email == "" {


### PR DESCRIPTION
This pull request introduces support for specifying a custom `QBEE_BASEURL` to allow users to authenticate against different `qbee.io` instances. The changes include updates to the documentation and the `login` command logic to handle the new environment variable.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R51-R59): Added instructions for setting the `QBEE_BASEURL` environment variable to authenticate against a custom `qbee.io` instance.

### Code Updates:
* `cmd/login.go`:
  - Added support for reading the `QBEE_BASEURL` environment variable in the `login` command.
  - Updated the logic to use the `QBEE_BASEURL` from command-line options if the environment variable is not set.