### PR TITLE
Add 'changes' and remove 'action' field from the Commit API payload

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -62,22 +62,23 @@ type Commit struct {
 
 // CommitRequest is a request to commit uncommitted changes.
 type CommitRequest struct {
-	// Action must be always set to "commit".
-	Action string `json:"action"`
-
 	// Message describing changes in the commit.
 	Message string `json:"message"`
+
+	// Changes is the list of changes' SHA that are part of the commit.
+	Changes []Change `json:"changes,omitempty"`
 }
 
-const commitAction = "commit"
-
 // CommitConfiguration commits uncommitted changes with provided message.
-func (cli *Client) CommitConfiguration(ctx context.Context, message string) (*Commit, error) {
+func (cli *Client) CommitConfiguration(ctx context.Context, message string, changes ...Change) (*Commit, error) {
 	const path = "/api/v2/commit"
 
 	request := CommitRequest{
-		Action:  commitAction,
 		Message: message,
+	}
+
+	if len(changes) > 0 {
+		request.Changes = changes
 	}
 
 	auditCommit := new(Commit)


### PR DESCRIPTION
This pull request updates the commit logic to allow specifying which changes are included in a commit, offering more granular control over the commit process. The main changes involve updating the `CommitRequest` structure and the `CommitConfiguration` method.

Enhancements to commit functionality:

* Removed the `Action` field from the `CommitRequest` struct and the associated constant, simplifying the request structure.
* Added a `Changes` field to the `CommitRequest` struct, allowing a list of `Change` objects (by SHA) to be included in a commit.
* Modified the `CommitConfiguration` method to accept a variadic list of `Change` arguments, which are added to the request if provided.