### PR TITLE
Bump Go version 1.25.7 -> 1.25.9

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.25.7
+          go-version: 1.25.9
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.25.7
+          go-version: 1.25.9
       - name: Build and test
         env:
           QBEE_EMAIL: ${{ secrets.QBEE_API_USER }}
@@ -25,7 +25,7 @@ jobs:
       - id: govulncheck
         uses: golang/govulncheck-action@v1
         with:
-          go-version-input: 1.25.7
+          go-version-input: 1.25.9
           go-package: ./...
       - name: golint
         run: go run golang.org/x/lint/golint@latest ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.qbee.io/client
 
-go 1.25.7
+go 1.25.9
 
 require (
 	github.com/xtaci/smux v1.5.55


### PR DESCRIPTION
This pull request updates the Go version used throughout the project from 1.25.7 to 1.25.9. The change ensures that all workflows and the module definition are consistent with the new Go version, which may include important security and bug fixes.

Go version updates:

* Updated the Go version in the `go.mod` file to `1.25.9` to set the module's required version.
* Updated the Go version in the `golangci-lint` GitHub Actions workflow to `1.25.9`.
* Updated the Go version in the `pr-test` GitHub Actions workflow for both the setup and the `govulncheck` step to `1.25.9`. [[1]](diffhunk://#diff-cf34a98fd25d1698b625c9a988868d4cef5036692a76d1e28dc5aa42be237b9eL18-R18) [[2]](diffhunk://#diff-cf34a98fd25d1698b625c9a988868d4cef5036692a76d1e28dc5aa42be237b9eL28-R28)