### PR TITLE
Use streaming for UploadFileReplace

### DIFF
--- a/files.go
+++ b/files.go
@@ -17,7 +17,6 @@
 package client
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -38,46 +37,56 @@ func (cli *Client) UploadFile(ctx context.Context, path, name string, reader io.
 
 // UploadFileReplace a file to the file-manager if replace is set to true
 func (cli *Client) UploadFileReplace(ctx context.Context, path, name string, replace bool, reader io.Reader) error {
-	buf := new(bytes.Buffer)
-	multipartWriter := multipart.NewWriter(buf)
+	pipeReader, pipeWriter := io.Pipe()
 
-	partHeaders := make(textproto.MIMEHeader)
-	partHeaders.Set("Content-Disposition", fmt.Sprintf(`form-data; name="file"; filename="%s"`, name))
-	partHeaders.Set("Content-Type", "")
+	multipartWriter := multipart.NewWriter(pipeWriter)
 
-	part, err := multipartWriter.CreatePart(partHeaders)
-	if err != nil {
-		return err
-	}
+	go func() {
+		var err error
 
-	if _, err = io.Copy(part, reader); err != nil {
-		return err
-	}
+		defer func() {
+			_ = pipeWriter.CloseWithError(err)
+		}()
 
-	if part, err = multipartWriter.CreateFormField("path"); err != nil {
-		return err
-	}
+		partHeaders := make(textproto.MIMEHeader)
+		partHeaders.Set("Content-Disposition", fmt.Sprintf(`form-data; name="file"; filename="%s"`, name))
+		partHeaders.Set("Content-Type", "")
 
-	if _, err = part.Write([]byte(path)); err != nil {
-		return err
-	}
+		var part io.Writer
 
-	if part, err = multipartWriter.CreateFormField("replace"); err != nil {
-		return err
-	}
+		if part, err = multipartWriter.CreatePart(partHeaders); err != nil {
+			return
+		}
 
-	if _, err = fmt.Fprintf(part, "%t", replace); err != nil {
-		return err
-	}
+		if _, err = io.Copy(part, reader); err != nil {
+			return
+		}
 
-	if err = multipartWriter.Close(); err != nil {
-		return err
-	}
+		if part, err = multipartWriter.CreateFormField("path"); err != nil {
+			return
+		}
+
+		if _, err = part.Write([]byte(path)); err != nil {
+			return
+		}
+
+		if part, err = multipartWriter.CreateFormField("replace"); err != nil {
+			return
+		}
+
+		if _, err = fmt.Fprintf(part, "%t", replace); err != nil {
+			return
+		}
+
+		if err = multipartWriter.Close(); err != nil {
+			return
+		}
+	}()
 
 	requestURL := cli.baseURL + filePath
 
-	var request *http.Request
-	if request, err = http.NewRequestWithContext(ctx, http.MethodPost, requestURL, buf); err != nil {
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, requestURL, pipeReader)
+	if err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This pull request refactors the `UploadFileReplace` method in `files.go` to use a streaming approach for constructing and sending multipart form data, rather than buffering the entire file in memory. This change improves memory efficiency, especially for large files.

**File upload streaming improvements:**

* Switched from buffering the entire multipart request in memory using `bytes.Buffer` to streaming the multipart data via an `io.Pipe`, reducing memory usage for large file uploads.
* The multipart form creation and file reading are now performed in a goroutine, writing directly to the pipe, which allows the HTTP request to read the data as it is being generated.

**Minor cleanup:**

* Removed the unused import of `bytes` from `files.go`.