### PR TITLE
Patching June 2026

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,9 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
-          go-version: 1.25.9
-          cache: false
+          go-version-file: go.mod
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -13,9 +13,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: 1.25.9
+          go-version-file: go.mod
       - name: Build and test
         env:
           QBEE_EMAIL: ${{ secrets.QBEE_API_USER }}
@@ -25,7 +25,7 @@ jobs:
       - id: govulncheck
         uses: golang/govulncheck-action@v1
         with:
-          go-version-input: 1.25.9
+          go-version-file: go.mod
           go-package: ./...
       - name: golint
         run: go run golang.org/x/lint/golint@latest ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install stable Go version
         uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version-file: go.mod
 
       - name: Build binary
         run: go build $GCFLAGS -ldflags "$LDFLAGS" -o ${{ env.NAME }} ./cmd
@@ -87,7 +87,7 @@ jobs:
       - name: Install stable Go version
         uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version-file: go.mod
 
       - name: Setup DigiCert KeyLocker
         shell: bash
@@ -130,7 +130,7 @@ jobs:
       - name: Install stable Go version
         uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version-file: go.mod
 
       - name: Build binary for ${{ matrix.arch }}
         env:

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,11 @@
 module go.qbee.io/client
 
-go 1.25.9
+go 1.26
 
 require (
 	github.com/xtaci/smux v1.5.57
-	go.qbee.io/transport v1.26.18
-	golang.org/x/term v0.42.0
+	go.qbee.io/transport v1.26.25
+	golang.org/x/term v0.44.0
 )
 
-require golang.org/x/sys v0.43.0 // indirect
+require golang.org/x/sys v0.46.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/xtaci/smux v1.5.57 h1:N72VbGoSYxgcm6mPOYX0QzEZNVD3UI/JlVvAtXF+WrY=
 github.com/xtaci/smux v1.5.57/go.mod h1:IGQ9QYrBphmb/4aTnLEcJby0TNr3NV+OslIOMrX825Q=
-go.qbee.io/transport v1.26.18 h1:ARoJhCBRjdQM9WTW2T6ia/pmmBfhCt0nUkSZlpvCykg=
-go.qbee.io/transport v1.26.18/go.mod h1:SBtAKI5/BjXrXYGRDT04gSjyZxQiuvRApSDeFWeelh4=
-golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
-golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
-golang.org/x/term v0.42.0 h1:UiKe+zDFmJobeJ5ggPwOshJIVt6/Ft0rcfrXZDLWAWY=
-golang.org/x/term v0.42.0/go.mod h1:Dq/D+snpsbazcBG5+F9Q1n2rXV8Ma+71xEjTRufARgY=
+go.qbee.io/transport v1.26.25 h1:HUckZV5Umn6bFulEZ+sGx13RFJr2ZtfDLkFikxDaR58=
+go.qbee.io/transport v1.26.25/go.mod h1:SBtAKI5/BjXrXYGRDT04gSjyZxQiuvRApSDeFWeelh4=
+golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
+golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/term v0.44.0 h1:0rLvDRCtNj0gZkyIXhCyOb2OAzEhLVqc4B+hrsBhrmc=
+golang.org/x/term v0.44.0/go.mod h1:7ze4MdzUzLXpSAoFP1H0bOI9aXDqveSvatT5vKcFh2Y=


### PR DESCRIPTION
This pull request updates the Go version and dependencies across the project, and improves CI workflow consistency by standardizing how the Go version is specified. The main changes include bumping the Go version to 1.26, updating dependency versions in `go.mod`, and modifying GitHub Actions workflows to use the `go-version-file` option for version management.

Dependency and Go version updates:

* Updated the Go version in `go.mod` from 1.25.9 to 1.26, and bumped dependencies: `go.qbee.io/transport` to v1.26.25, `golang.org/x/term` to v0.44.0, and `golang.org/x/sys` to v0.46.0.

CI/CD workflow improvements:

* Updated all GitHub Actions workflows (`.github/workflows/golangci-lint.yml`, `.github/workflows/pr-test.yml`, `.github/workflows/release.yml`) to use `actions/setup-go@v6` with the `go-version-file: go.mod` option, ensuring that the Go version used in CI matches the version specified in `go.mod`. [[1]](diffhunk://#diff-d9a956120ac84289d2650137f64bd8f0893331de05e44cc41899dd984c9e0d48L19-R21) [[2]](diffhunk://#diff-cf34a98fd25d1698b625c9a988868d4cef5036692a76d1e28dc5aa42be237b9eL16-R18) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L55-R55) [[4]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L90-R90) [[5]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L133-R133)
* Updated the `govulncheck` step in `.github/workflows/pr-test.yml` to use `go-version-file: go.mod` instead of a hardcoded Go version.