### PR TITLE
Fix version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ env:
 
   # LDFLAGS with -s and -w reduces the binary size by omitting symbol table and debug information.
   # The -X flag sets the Version variable in the code to the release version.
-  DFLAGS: -s -w -X go.qbee.io/client.Version=${{ github.ref_name }}
+  LDFLAGS: -s -w -X go.qbee.io/client.Version=${{ github.ref_name }}
 
   # GOPROXY ensures that we use the correct Go module proxy.
   # We want our build process to start with populateding the Go proxy


### PR DESCRIPTION
This pull request makes a small change to the workflow configuration by correcting a variable name in the environment settings. The variable used to pass linker flags to the Go build process is now correctly named.

- Renamed the environment variable from `DFLAGS` to `LDFLAGS` in `.github/workflows/release.yml` to properly pass linker flags during the Go build process.